### PR TITLE
Ct 50 team grid style

### DIFF
--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import Grid from "@mui/material/Grid2";
 import { Box } from "@mui/material";
 import SectionTitle from "../SectionTitle";
 import { membersData } from "../../data/membersData";
@@ -21,19 +20,25 @@ export default function TeamGridLayout() {
     <Box
       sx={{
         flexGrow: 1,
-        px: { xs: "2rem", sm: "4rem", md: "10rem" },
+        px: { xs: "2rem", sm: "4rem", md: "6rem" },
       }}
     >
       <SectionTitle sectionTitle="Team" />
       {/* This grid - the grid container, contains the entire grid, the columns number is the number of total columns in the grid */}
-      <Grid
-        container spacing={{ xs: 2, md: 3 }}
-        columns={{ xs: 4, sm: 8, md: 12 }}
-        justifyContent="center"
-      >
+      <Box
+        // container spacing={{ xs: 2, md: 4 }}
+        // columns={{ xs: 4, sm: 8, md: 12 }}
+        display="flex"
+        flexDirection="row"
+        flexWrap="wrap"
+        justifyContent="center"      
+        >
         {membersData.map((member, index) => (
           // This grid is the individual grid square, the breakpoint of xs: 2, sm: 4, md: 4 say that on an xs screen each each grid square is 2/4 cols, at sm it is 4/8 , at md and larger it is 4/12 the container
-          <Grid size={{ xs: 2, sm: 4, md: 4 }} key={index}>
+          <Box 
+            // size={{ xs: 2, sm: 4, md: 4 }}
+            margin="1rem" 
+            key={index}>
             {/* Render front or back based on the flippedCardIndex */}
             {flippedCardIndex === index ? (
               <div onClick={() => toggleCard(index)}>
@@ -47,9 +52,9 @@ export default function TeamGridLayout() {
                 />
               </div>
             )}
-          </Grid>
+          </Box>
         ))}
-      </Grid>
+      </Box>
     </Box>
   );
 }

--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -16,7 +16,7 @@ export default function TeamGridLayout() {
     setFlippedCardIndex((prevIndex) => (prevIndex === index ? null : index));
   };
   return (
-    // The px should probably be universally applied to everything on the page except the header and footer
+    // ToDo The px should probably be universally applied to everything on the page except the header and footer
     <Box
       sx={{
         flexGrow: 1,

--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -24,19 +24,14 @@ export default function TeamGridLayout() {
       }}
     >
       <SectionTitle sectionTitle="Team" />
-      {/* This grid - the grid container, contains the entire grid, the columns number is the number of total columns in the grid */}
       <Box
-        // container spacing={{ xs: 2, md: 4 }}
-        // columns={{ xs: 4, sm: 8, md: 12 }}
         display="flex"
         flexDirection="row"
         flexWrap="wrap"
         justifyContent="center"      
         >
         {membersData.map((member, index) => (
-          // This grid is the individual grid square, the breakpoint of xs: 2, sm: 4, md: 4 say that on an xs screen each each grid square is 2/4 cols, at sm it is 4/8 , at md and larger it is 4/12 the container
           <Box 
-            // size={{ xs: 2, sm: 4, md: 4 }}
             margin="1rem" 
             key={index}>
             {/* Render front or back based on the flippedCardIndex */}

--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Grid from "@mui/material/Grid2";
+import { Box } from "@mui/material";
 import SectionTitle from "../SectionTitle";
 import { membersData } from "../../data/membersData";
 import TeamMemberCardFront from "../TeamMemberCardFront/index";
@@ -16,11 +17,14 @@ export default function TeamGridLayout() {
     setFlippedCardIndex((prevIndex) => (prevIndex === index ? null : index));
   };
   return (
-    <>
+    // The px should probably be universally applied to everything on the page except the header and footer
+    <Box sx={{ flexGrow: 1, px:"10rem" }}>
       <SectionTitle sectionTitle="Team" />
-      <Grid container spacing={2} justifyContent="center">
+      {/* This grid - the grid container, contains the entire grid */}
+      <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }} justifyContent="center">
         {membersData.map((member, index) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={index}>
+          // This grid is the individual grid square, the breakpoint of xs: 2, sm: 4, md: 4 say that on an xs screen each each grid square is 2/12 cols, at sm it is 4/12 , at md and larger it is 4/12 the container
+          <Grid size={{ xs: 2, sm: 4, md: 4 }} key={index}>
             {/* Render front or back based on the flippedCardIndex */}
             {flippedCardIndex === index ? (
               <div onClick={() => toggleCard(index)}>
@@ -37,6 +41,6 @@ export default function TeamGridLayout() {
           </Grid>
         ))}
       </Grid>
-    </>
+    </Box>
   );
 }

--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -18,12 +18,21 @@ export default function TeamGridLayout() {
   };
   return (
     // The px should probably be universally applied to everything on the page except the header and footer
-    <Box sx={{ flexGrow: 1, px:"10rem" }}>
+    <Box
+      sx={{
+        flexGrow: 1,
+        px: { xs: "2rem", sm: "4rem", md: "10rem" },
+      }}
+    >
       <SectionTitle sectionTitle="Team" />
-      {/* This grid - the grid container, contains the entire grid */}
-      <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }} justifyContent="center">
+      {/* This grid - the grid container, contains the entire grid, the columns number is the number of total columns in the grid */}
+      <Grid
+        container spacing={{ xs: 2, md: 3 }}
+        columns={{ xs: 4, sm: 8, md: 12 }}
+        justifyContent="center"
+      >
         {membersData.map((member, index) => (
-          // This grid is the individual grid square, the breakpoint of xs: 2, sm: 4, md: 4 say that on an xs screen each each grid square is 2/12 cols, at sm it is 4/12 , at md and larger it is 4/12 the container
+          // This grid is the individual grid square, the breakpoint of xs: 2, sm: 4, md: 4 say that on an xs screen each each grid square is 2/4 cols, at sm it is 4/8 , at md and larger it is 4/12 the container
           <Grid size={{ xs: 2, sm: 4, md: 4 }} key={index}>
             {/* Render front or back based on the flippedCardIndex */}
             {flippedCardIndex === index ? (

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -64,8 +64,8 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
           alt={name}
           src={avatar}
           sx={{
-            width: "fit-content", // Avatar width as a percentage of viewport width
-            height: "fit-content", // Avatar height as a percentage of viewport width
+            width: "100%",
+            height: "100%",
             maxWidth: "10rem", // Maximum width to prevent it from growing too large
             maxHeight: "10rem", // Maximum height to prevent it from growing too large
           }}

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -30,7 +30,7 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
     <Card
       className="team-member-card"
       sx={{
-        width: "280px",
+        maxWidth: "280px",
         aspectRatio: "1 / 1",
         overflow: "hidden", // Prevents overflow
         display: "flex", // Use flexbox for child elements
@@ -44,8 +44,7 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
         title={name}
         sx={{
           textAlign: "center",
-          padding: "0 1rem",
-          margin:"1rem"
+          padding: "0 1rem .5rem",
         }}
       >
         <Typography variant="h5">{name}</Typography>
@@ -64,10 +63,9 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
           alt={name}
           src={avatar}
           sx={{
-            width: "100%",
-            height: "100%",
-            maxWidth: "10rem", // Maximum width to prevent it from growing too large
-            maxHeight: "10rem", // Maximum height to prevent it from growing too large
+            width: "6rem", // Maximum width to prevent it from growing too large
+            height: "6rem", // Maximum height to prevent it from growing too large
+            aspectRatio: "1 / 1",
           }}
         />
         <Box

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -5,7 +5,7 @@ import {
   CardContent,
   Typography,
   Avatar,
-  Box
+  Box,
 } from "@mui/material";
 
 // Import the MemberInfo type
@@ -31,55 +31,65 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
       className="team-member-card"
       sx={{
         position: "relative", // Position relative for the inner content
-        width: "100%", // Make the card full width of the grid item
-        paddingTop: "100%", // Matching the padding top to the width creates a square aspect ratio
+        width: "280px", // Make the card full width of the grid item
+        aspectRatio: "1 / 1",
         overflow: "hidden", // Prevents overflow
+        display: "flex", // Use flexbox for child elements
+        flexDirection: "column", // Stack children vertically
+        justifyContent: "space-between", // Distribute the children evenly
+        alignItems: "center", // Center content horizontally
+        margin: "auto", // Center the card horizontally
+        padding:"1rem"
       }}
     >
       <CardHeader
         title={name}
         sx={{
-          pb: 0,
-          position: "absolute",
-          top: 0,
-          left: 0,
-          right: 0,
           textAlign: "center",
+          padding: "0 1rem",
+          margin:"1rem"
         }}
       >
         <Typography variant="h5">{name}</Typography>
       </CardHeader>
       <CardContent
         sx={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)", // Center the content
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
+          flexGrow: 1, // Allow this section to grow
+          p:0
         }}
       >
-        <Avatar 
-          alt={name} 
-          src={avatar} 
-          sx={{ 
-              width: 120,
-              height: 120,
-              paddingBottom: 0
-              }} />
+        <Avatar
+          alt={name}
+          src={avatar}
+          sx={{
+            // width: "20vw", // Avatar width as a percentage of viewport width
+            // height: "20vw", // Avatar height as a percentage of viewport width
+            width: "max-content", // Avatar width as a percentage of viewport width
+            height: "max-content", // Avatar height as a percentage of viewport width
+            maxWidth: "10rem", // Maximum width to prevent it from growing too large
+            maxHeight: "10rem", // Maximum height to prevent it from growing too large
+          }}
+        />
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            flexGrow: 1, // Allow this section to grow
+            px: { xs: "1rem", sm: "2rem" }, // Responsive padding for better spacing
+            // marginTop: "auto", // Keep the link bar at the bottom of the card
+                      padding: "0 1rem",
+            margin:"1rem",
+          }}
+        >
+          <TeamLinkBar memberInfo={memberInfo} />
+        </Box>
       </CardContent>
-      <Box        
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <TeamLinkBar memberInfo={memberInfo} />         
-      </Box>
     </Card>
   );
 };

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -31,8 +31,8 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
       className="team-member-card"
       sx={{
         position: "relative", // Position relative for the inner content
-        width: "40%", // Make the card full width of the grid item
-        paddingTop: "40%", // Matching the padding top to the width creates a square aspect ratio
+        width: "100%", // Make the card full width of the grid item
+        paddingTop: "100%", // Matching the padding top to the width creates a square aspect ratio
         overflow: "hidden", // Prevents overflow
       }}
     >

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -63,8 +63,8 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
           alt={name}
           src={avatar}
           sx={{
-            width: "6rem", // Maximum width to prevent it from growing too large
-            height: "6rem", // Maximum height to prevent it from growing too large
+            width: "6rem",
+            height: "6rem",
             aspectRatio: "1 / 1",
           }}
         />

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -31,7 +31,7 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
       className="team-member-card"
       sx={{
         maxWidth: "280px",
-        aspectRatio: "1 / 1",
+        aspectRatio: "1 / 1", //sets height/width ratio
         overflow: "hidden", // Prevents overflow
         display: "flex", // Use flexbox for child elements
         flexDirection: "column", // Stack children vertically

--- a/src/components/TeamMemberCardFront/index.tsx
+++ b/src/components/TeamMemberCardFront/index.tsx
@@ -30,15 +30,13 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
     <Card
       className="team-member-card"
       sx={{
-        position: "relative", // Position relative for the inner content
-        width: "280px", // Make the card full width of the grid item
+        width: "280px",
         aspectRatio: "1 / 1",
         overflow: "hidden", // Prevents overflow
         display: "flex", // Use flexbox for child elements
         flexDirection: "column", // Stack children vertically
         justifyContent: "space-between", // Distribute the children evenly
         alignItems: "center", // Center content horizontally
-        margin: "auto", // Center the card horizontally
         padding:"1rem"
       }}
     >
@@ -66,10 +64,8 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
           alt={name}
           src={avatar}
           sx={{
-            // width: "20vw", // Avatar width as a percentage of viewport width
-            // height: "20vw", // Avatar height as a percentage of viewport width
-            width: "max-content", // Avatar width as a percentage of viewport width
-            height: "max-content", // Avatar height as a percentage of viewport width
+            width: "fit-content", // Avatar width as a percentage of viewport width
+            height: "fit-content", // Avatar height as a percentage of viewport width
             maxWidth: "10rem", // Maximum width to prevent it from growing too large
             maxHeight: "10rem", // Maximum height to prevent it from growing too large
           }}
@@ -81,9 +77,8 @@ const TeamMemberCardFront: React.FC<TeamMemberCardFrontProps> = ({
             justifyContent: "center",
             alignItems: "center",
             flexGrow: 1, // Allow this section to grow
-            px: { xs: "1rem", sm: "2rem" }, // Responsive padding for better spacing
-            // marginTop: "auto", // Keep the link bar at the bottom of the card
-                      padding: "0 1rem",
+            px: "2rem", 
+            padding: "0 1rem",
             margin:"1rem",
           }}
         >


### PR DESCRIPTION
## Purpose

This PR covers issue CT-50 - making the team section match the figma for the non-mobile views. I think there is room to decide if the max size of the card is visually "correct" - but I think that is a simple change that we can do once we have a better picture of the overall page.

This is the figma:
![image](https://github.com/user-attachments/assets/50666738-c18e-48c2-9ef1-0be67da13a39)

## Changes

The Grid MUI component has been removed and replaced with the Box Mui component. Box with flexbox utilities is a cleaner and simpler way to meet the design intent. Aside from the Grid component being switched for the Box component there are many inline CSS changes.

## Steps to Reproduce or Test

This is the expected appearance on a large screen. On mobile sizes it should drop down to one row, but that is not important because our mobile size design is a carousel.

![image](https://github.com/user-attachments/assets/ccc0582c-5243-418e-a624-63ca4db2aadb)

