### PR TITLE
Ct 73 contact form change to minimal for mvp

### DIFF
--- a/src/components/ContactDialog/index.tsx
+++ b/src/components/ContactDialog/index.tsx
@@ -2,7 +2,7 @@ import { Dialog, DialogActions, DialogTitle, Button } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import TextField from "@mui/material/TextField";
 import FormHelperText from "@mui/material/FormHelperText";
-
+import Typography from "@mui/material/Typography";
 export interface ContactDialogProps {
   open: boolean;
   selectedValue: string;
@@ -21,25 +21,36 @@ export default function ContactDialog(props: ContactDialogProps) {
         <Grid container spacing={2} padding={4}>
           <Grid container spacing={3} padding={2}>
             <Grid>
-              <TextField
+              <Typography variant="body1">
+                Want to join our team?
+                <br />
+                Send feedback on the website?
+                <br />
+                Have a question about our services?
+              </Typography>
+              {/* <TextField
                 id="first-name"
                 label="First Name"
                 required
                 variant="standard"
                 fullWidth
-              />
+              /> */}
             </Grid>
             <Grid>
-              <TextField
+              <Typography variant="body1">
+                <br />
+                <a href="mailto:hello@crestonetech.com">hello@crestonetech.com</a>
+              </Typography>
+              {/* <TextField
                 id="last-name"
                 label="Last Name"
                 required
                 variant="standard"
                 fullWidth
-              />
+              /> */}
             </Grid>
           </Grid>
-          <Grid padding={2}>
+          {/* <Grid padding={2}>
             <TextField
               id="email"
               label="Email"
@@ -70,11 +81,11 @@ export default function ContactDialog(props: ContactDialogProps) {
               placeholder="Message"
               sx={{ marginTop: 2 }} // Add spacing above
             />
-          </Grid>
+          </Grid> */}
         </Grid>
         <DialogActions>
-          <Button onClick={handleClose}>Cancel</Button>
-          <Button type="submit">Send Message</Button>
+          <Button onClick={handleClose}>Close</Button>
+          {/* <Button type="submit">Send Message</Button> */}
         </DialogActions>
       </Dialog>
     </>

--- a/src/components/ContactDialog/index.tsx
+++ b/src/components/ContactDialog/index.tsx
@@ -3,6 +3,9 @@ import Grid from "@mui/material/Grid2";
 import TextField from "@mui/material/TextField";
 import FormHelperText from "@mui/material/FormHelperText";
 import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
 export interface ContactDialogProps {
   open: boolean;
   selectedValue: string;
@@ -26,7 +29,7 @@ export default function ContactDialog(props: ContactDialogProps) {
                 <br />
                 Send feedback on the website?
                 <br />
-                Have a question about our services?
+                Have a question about our <br /> services?
               </Typography>
               {/* <TextField
                 id="first-name"
@@ -39,7 +42,16 @@ export default function ContactDialog(props: ContactDialogProps) {
             <Grid>
               <Typography variant="body1">
                 <br />
-                <a href="mailto:hello@crestonetech.com">hello@crestonetech.com</a>
+                hello@crestonetech.com
+                <IconButton
+                  onClick={() => {
+                    navigator.clipboard.writeText("hello@crestonetech.com");
+                  }}
+                  size="small"
+                  sx={{ ml: 1 }}
+                >
+                  <ContentCopyIcon fontSize="small" />
+                </IconButton>
               </Typography>
               {/* <TextField
                 id="last-name"

--- a/src/components/ContactDialog/index.tsx
+++ b/src/components/ContactDialog/index.tsx
@@ -1,7 +1,7 @@
 import { Dialog, DialogActions, DialogTitle, Button } from "@mui/material";
 import Grid from "@mui/material/Grid2";
-import TextField from "@mui/material/TextField";
-import FormHelperText from "@mui/material/FormHelperText";
+// import TextField from "@mui/material/TextField";
+// import FormHelperText from "@mui/material/FormHelperText";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -31,7 +31,8 @@ export default function ContactDialog(props: ContactDialogProps) {
                 <br />
                 Have a question about our <br /> services?
               </Typography>
-              {/* <TextField
+              {/* commented fields preserve the work done earlier for a form that would send an email
+              <TextField
                 id="first-name"
                 label="First Name"
                 required


### PR DESCRIPTION
## Purpose

Provide the simplest viable contact form: a dialog with our email address.
Why? because sending an email through the site is proving to be a lot of work! It requires adding a back end. That's great as a learning experience but has been holding up the MVP deployment.

This simpler goal enables MVP go-live.

Fixes [CT-73](https://crestonetech.atlassian.net/browse/CT-73)

## Changes

components/Contact/index.ts
- preserves the text fields that were implemented already for a more fleshed-out dialog. No sense tossing them out.
- replaces them with simpler contents

## Steps to Reproduce or Test

- npm run dev
- click Contact
- to close: you can do any of 
-- click close
-- click away
-- press Esc (this is an accessibility standard and seems to be built into this MUI dialog component. Nice)

[CT-73]: https://crestonetech.atlassian.net/browse/CT-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ