### PR TITLE
CT-81-disable-card-flip-make-ready-simply-preserve-flip-for-future-use

### DIFF
--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -31,10 +31,19 @@ export default function TeamGridLayout() {
         justifyContent="center"
       >
         {membersData.map((member, index) => (
-          <Box 
-            margin="1rem" 
-            key={index}>
-            {/* Render front or back based on the flippedCardIndex */}
+          <Box margin="1rem" key={index}>
+            <div onClick={() => toggleCard(index)}>
+              <TeamMemberCardFront
+                // passing member object to TeamMemberCardFront
+                memberInfo={member}
+              />
+            </div>
+
+            {/* Preserving the ability to flip the cards. For MVP, we are simplifying, not flipping the cards
+
+              See Story CT-81 
+            https://crestonetech.atlassian.net/browse/CT-81?atlOrigin=eyJpIjoiYjhmZTk5YjM5NDAwNDhlYjg2MmNhOTczN2NmN2EzNjMiLCJwIjoiaiJ9
+
             {flippedCardIndex === index ? (
               <div onClick={() => toggleCard(index)}>
                 <TeamMemberCardBack
@@ -49,7 +58,7 @@ export default function TeamGridLayout() {
                   memberInfo={member}
                 />
               </div>
-            )}
+            )} */}
           </Box>
         ))}
       </Box>

--- a/src/components/TeamGridLayout/index.tsx
+++ b/src/components/TeamGridLayout/index.tsx
@@ -1,20 +1,27 @@
-import { useState } from "react";
+// for CT-81, to finish the MVP release, we are 
+// - simplifying, not flipping the cards
+// - preserving the ability to flip the cards by commenting and keeping code (below)
+//   See Story CT-81 
+            // https://crestonetech.atlassian.net/browse/CT-81?atlOrigin=eyJpIjoiYjhmZTk5YjM5NDAwNDhlYjg2MmNhOTczN2NmN2EzNjMiLCJwIjoiaiJ9
+// CT-81 import { useState } from "react";
 import { Box } from "@mui/material";
 import SectionTitle from "../SectionTitle";
 import { membersData } from "../../data/membersData";
 import TeamMemberCardFront from "../TeamMemberCardFront/index";
-import TeamMemberCardBack from "../TeamMemberCardBack/index";
+// CT-81 import TeamMemberCardBack from "../TeamMemberCardBack/index";
 
 export default function TeamGridLayout() {
   // State to track the index of the currently flipped card
-  const [flippedCardIndex, setFlippedCardIndex] = useState<number | null>(null);
+  // CT-81
+  // const [flippedCardIndex, setFlippedCardIndex] = useState<number | null>(null);
 
   // Function to toggle the card flip state
-  const toggleCard = (index: number) => {
-    // If the clicked card is already flipped, set it to null (flip back)
-    // Otherwise, set the index of the clicked card
-    setFlippedCardIndex((prevIndex) => (prevIndex === index ? null : index));
-  };
+  // CT-81
+  // const toggleCard = (index: number) => {
+  //   // If the clicked card is already flipped, set it to null (flip back)
+  //   // Otherwise, set the index of the clicked card
+  //   setFlippedCardIndex((prevIndex) => (prevIndex === index ? null : index));
+  // };
   return (
     // ToDo The px should probably be universally applied to everything on the page except the header and footer
     <Box
@@ -32,17 +39,15 @@ export default function TeamGridLayout() {
       >
         {membersData.map((member, index) => (
           <Box margin="1rem" key={index}>
-            <div onClick={() => toggleCard(index)}>
+            {/* CT-81 <div onClick={() => toggleCard(index)}> */}
+            <div>
               <TeamMemberCardFront
                 // passing member object to TeamMemberCardFront
                 memberInfo={member}
               />
             </div>
 
-            {/* Preserving the ability to flip the cards. For MVP, we are simplifying, not flipping the cards
-
-              See Story CT-81 
-            https://crestonetech.atlassian.net/browse/CT-81?atlOrigin=eyJpIjoiYjhmZTk5YjM5NDAwNDhlYjg2MmNhOTczN2NmN2EzNjMiLCJwIjoiaiJ9
+            {/* See Story CT-81 for why this is commented out
 
             {flippedCardIndex === index ? (
               <div onClick={() => toggleCard(index)}>

--- a/src/components/TeamLinkBar/index.tsx
+++ b/src/components/TeamLinkBar/index.tsx
@@ -10,35 +10,29 @@ interface TeamLinkBarProps {
 
 export default function TeamLinkBar({ memberInfo }: TeamLinkBarProps) {
   return (
-    <Box 
- >
+    <Box>
       <Tooltip title="GitHub Profile">
         <IconButton
           onClick={() => {
             window.open(memberInfo.github);
           }}
           sx={{
-            minWidth: "40px",  // Set a min size for the icon button
-            maxWidth: "60px",  // Set a max size for the icon button
-            fontSize: "1.5rem",  // Default size for the icon
+            minWidth: "40px", // Set a min size for the icon button
+            maxWidth: "60px", // Set a max size for the icon button
+            fontSize: "1.5rem", // Default size for the icon
             "& .MuiSvgIcon-root": {
-              fontSize: "inherit",  // Inherit the font size from the IconButton
+              fontSize: "inherit", // Inherit the font size from the IconButton
             },
           }}
         >
-          
           <GitHubIcon />
         </IconButton>
       </Tooltip>
-      <Tooltip title="Email me. But this doesn't work yet. Sadness.">
+      <Tooltip title="Copies my email address to the clipboard">
         <IconButton
-        // MS Co-Pilot gave me the code below, but doing this on my machine results in an
-        // opening a new browser tab, with the mailto link in the address bar - but the tab
-        // is blank and nothing really happens.
-        //
-        // onClick={() => {
-        //   window.open(`mailto:${member.email}`);
-        // }}
+          onClick={() => {
+            navigator.clipboard.writeText(memberInfo.email);
+          }}
         >
           <EmailIcon />
         </IconButton>


### PR DESCRIPTION
## Purpose

Solves 2 problems
1. we haven't completed the bios or the back of the cards. 
MVP solution: 
- disable the card flip
- preserve the flipping code so that we could restore/complete it later
2. email link button disabled because mailto: links produce varying results
MVP solution: 
- remove mailto link
- when user clicks the email button, copy the email address to the clipboard

Fixes https://crestonetech.atlassian.net/browse/CT-81

## Changes



## Steps to Reproduce or Test

1. click the Team section
2. DO click a team member
3. CONFIRM that the card does not flip
4. DO hover over the email icon for a team member
5. CONFIRM the tooltip
6. DO click the email icon
7. DO paste into an email program, text editor, any way you can see the text pasted from the clipboard
8. CONFIRM the email address pasted